### PR TITLE
- widen range for mock dependency to support Angular2 beta.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 packages
+.packages
+.pub
 pubspec.lock

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,10 +3,10 @@ version: 0.4.2
 description: >
   Sass-transformer for pub-serve and pub-build.
 author: Juha Komulainen <juha.komulainen@evident.fi>
-homepage: https://bitbucket.org/evidentsolutions/dart-sass
+homepage: https://github.com/EvidentSolutions/dart-sass
 dependencies:
   barback: ">=0.15.0 <0.16.0"
   utf: ">=0.9.0 <0.9.1"
 dev_dependencies:
-  unittest: ">=0.11.0 <0.12.0"
-  mock: ">=0.11.0 <0.12.0"
+  test: ">=0.12.0 <0.13.0"
+  mock: ">=0.11.0 <0.13.0"

--- a/test/inlined_sass_transformer_test.dart
+++ b/test/inlined_sass_transformer_test.dart
@@ -1,7 +1,8 @@
+@TestOn('vm')
 library sass.inlined_transformer_test;
 
 import 'dart:async';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:mock/mock.dart';
 import 'package:barback/barback.dart';
 import 'package:sass/sass.dart';

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -1,7 +1,8 @@
+@TestOn('vm')
 library sass.transformer.test;
 
 import 'dart:async';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:sass/transformer.dart';
 import 'package:barback/barback.dart';
 

--- a/test/sass_file_test.dart
+++ b/test/sass_file_test.dart
@@ -1,6 +1,7 @@
+@TestOn('vm')
 library sass.sass_file_test;
 
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:sass/transformer.dart';
 
 void main() => group("SassFile", () {

--- a/test/sass_test.dart
+++ b/test/sass_test.dart
@@ -1,9 +1,13 @@
+@TestOn('vm')
 library sass.test;
 
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:sass/sass.dart';
 
 main(List<String> args) {
+  Matcher regexMatch(RegExp regexp) =>
+      predicate((String s) => regexp.hasMatch(s));
+
   group('Basic SCSS tests', () {
     Sass sass = new Sass();
     sass.scss = true;
@@ -11,15 +15,22 @@ main(List<String> args) {
 
     if (!args.contains('--no-sass')) {
       test('Sass', () {
+        final expected = regexMatch(new RegExp("^h1 h2\s*{color:red}\n\$"));
         sass.executable = 'sass';
-        expect(sass.transform('h1 { h2 { color: red } }'), completion(equals("h1 h2{color:red}\n")));
+        expect(
+            sass.transform('h1 { h2 { color: red } }'), completion(expected));
+
+        expect(sass.transform('h1 { h2{ color: red } }'), completion(expected));
       });
     }
 
     if (!args.contains('--no-sassc')) {
       test('SassC', () {
+        final expected = regexMatch(new RegExp("^h1 h2\s*{color:red}\n\$"));
         sass.executable = 'sassc';
-        expect(sass.transform('h1 { h2 { color: red } }'), completion(equals("h1 h2 {color:red;}")));
+        expect(
+            sass.transform('h1 { h2 { color: red } }'), completion(expected));
+        expect(sass.transform('h1 { h2{ color: red } }'), completion(expected));
       });
     }
   });

--- a/test/transformer_test.dart
+++ b/test/transformer_test.dart
@@ -1,7 +1,7 @@
+@TestOn('vm')
 library sass.transformer.test;
 
-import 'dart:async';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:mock/mock.dart';
 import 'package:sass/transformer.dart';
 import 'package:barback/barback.dart';


### PR DESCRIPTION
- migrate from unittest to test
- migrated two tests to use regexp instead of plain string comparison because of whitespace differences
- update .gitignore
- fix homepage URL in pubspec.yaml

includes #4
